### PR TITLE
Using Pillow instead of PIL

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     author = 'Alexander Artemenko',
     author_email = 'svetlyak.40wt@gmail.com',
     url = 'http://github.com/svetlyak40wt/django-counter/',
-    install_requires = ['PIL'],
+    install_requires = ['Pillow'],
     dependency_links = [],
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',


### PR DESCRIPTION
Pillow is a wrapper around PIL to make it play nicely with virtualenv and similar. Otherwise the functionality remains the same.
